### PR TITLE
Loot reference

### DIFF
--- a/src/bindings/CMakeLists.txt
+++ b/src/bindings/CMakeLists.txt
@@ -16,4 +16,4 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #
 
-add_subdirectory(ScriptDev2)
+# add_subdirectory(universal)


### PR DESCRIPTION
Поддержка группировки добычи которая ссылается на другую добычу.
