### PR TITLE
Small correction in Camera

### DIFF
--- a/src/game/Camera.h
+++ b/src/game/Camera.h
@@ -105,7 +105,7 @@ class MANGOS_DLL_SPEC ViewPoint
 
     public:
 
-        ViewPoint(WorldObject& object) : m_body(object), m_grid(NULL) 
+        ViewPoint(WorldObject& object) : m_grid(NULL), m_body(object) 
         {
             m_cameras.clear();
         }


### PR DESCRIPTION
To prevent warnings, members should appear in the initializer in the same order as they appear in the class
