### PR TITLE
Fix decimate from Stinky and Precious

### DIFF
--- a/src/game/SpellEffects.cpp
+++ b/src/game/SpellEffects.cpp
@@ -371,16 +371,6 @@ void Spell::EffectSchoolDMG(SpellEffectIndex effect_idx)
                             damage = m_caster->GetMaxPower(POWER_MANA);
                         break;
                     }
-                    case 28375:     // Decimate (Gluth encounter)
-                    {
-                        // leave only 5% HP
-                        if (unitTarget)
-                        {
-                            // damage of this spell is very odd so we're setting HP manually
-                            damage = 0;
-                            unitTarget->SetHealthPercent(5.0f);
-                        }
-                    }
                     // percent max target health
                     case 29142:                             // Eyesore Blaster
                     case 35139:                             // Throw Boom's Doom


### PR DESCRIPTION
Remove a fix for spell 28375, already handled by script effects from 28374, 54426 and 71123.
