### PR TITLE
Rework partial spell resistance with wotlk system

### DIFF
--- a/src/game/Unit.cpp
+++ b/src/game/Unit.cpp
@@ -2185,28 +2185,38 @@ void Unit::CalculateDamageAbsorbAndResist(Unit *pCaster, DamageInfo* damageInfo,
         if (pCaster->GetTypeId() == TYPEID_PLAYER)
             tmpvalue2 -= (float)((Player*)pCaster)->GetSpellPenetrationItemMod();
 
-        tmpvalue2 *= (float)(0.15f / getLevel());
-        if (tmpvalue2 < 0.0f)
-            tmpvalue2 = 0.0f;
-        if (tmpvalue2 > 0.75f)
-            tmpvalue2 = 0.75f;
-        uint32 ran = urand(0, 100);
-        float faq[4] = {24.0f,6.0f,4.0f,6.0f};
-        uint8 m = 0;
-        float Binom = 0.0f;
-        for (uint8 i = 0; i < 4; ++i)
+        if (pCaster->getLevel()>80)
+            tmpvalue2 *= (float)(1.0f / (tmpvalue2 + 510));
+        else
+            tmpvalue2 *= (float)(1.0f / (tmpvalue2 + 400));
+
+        float ran = (float)urand(0, 100);
+        int maxcoeff = (int)(tmpvalue2*10)+2;
+
+        for (uint8 i = 0; i < 5; ++i) //Inverser la resist
         {
-            Binom += 2400 *( pow(tmpvalue2, float(i)) * pow( (1-tmpvalue2), float(4-i)))/faq[i];
-            if (ran > Binom )
-                ++m;
-            else
+            float resis = 0.1f * (float)(maxcoeff-i);
+            float proba = 0.5f - 2.5f * abs(resis - tmpvalue2);
+            ran -= 100.0f * proba;
+            if (ran < 0)
+            {
+                tmpvalue2 = resis;
                 break;
+            }
         }
-        if (damageInfo->damageType == DOT && m == 4)
+
+        if (ran >= 0)
+            tmpvalue2 = 0.1f * (float)(maxcoeff-4);
+        if(tmpvalue2 < 0)
+            tmpvalue2 = 0.0f;
+        else if(tmpvalue2 > 1) //Should never happen
+            tmpvalue2 = 1.0f;
+
+        if (damageInfo->damageType == DOT && tmpvalue2 == 1.0f)
             damageInfo->resist += uint32(damageInfo->damage);
             // need make more correct this hack.
         else
-            damageInfo->resist += uint32(damageInfo->damage * m / 4);
+            damageInfo->resist += uint32(damageInfo->damage * tmpvalue2);
 
         // full resist mode granted
         if (damageInfo->resist > damageInfo->damage)


### PR DESCRIPTION
Current system allows 0 - 25 - 50 - 75 - 100% resistance, which is Battle Crusade system.
Wotlk system has 10% steps.
I made this patch using this discussion : 
http://elitistjerks.com/f15/t44675-resistance_mechanics_wotlk/
